### PR TITLE
Only allow pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# Unsupported package managers 
+package-lock.json
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
+    "preinstall": "npx -y only-allow pnpm",
     "postinstall": "prisma generate",
     "lint": "next lint",
     "start": "next start"


### PR DESCRIPTION
This pull request includes changes to prevent devs from using a package manager other than `pnpm` by throwing an error and showing the following:

![image](https://user-images.githubusercontent.com/56479869/197806595-816e17db-2338-4ec2-8965-cd000eaa3660.png)
